### PR TITLE
Make os_id_like in /etc/os-release optional

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -197,7 +197,7 @@ if [ -f /etc/os-release ]; then
     )"
     {
         read -r os_id
-        read -r os_id_like
+        read -r os_id_like || true
         read -r os_version_id
         read -r os_version_codename || true
     } <<<"$os_info"


### PR DESCRIPTION
From the spec examples, it seems that it is intended to be optional (see https://www.freedesktop.org/software/systemd/man/os-release.html#Examples).
In my concrete case, Debian doesn't provide ID_LIKE by default.

**Testing plan:** Came up during my install.
